### PR TITLE
Increased minimum Ansible version to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,22 @@ env:
 matrix:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=centos
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=debian_max
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=debian_min
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=ubuntu_max
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=ubuntu_min
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=opensuse
     - env:
         - MOLECULEW_ANSIBLE=2.9.1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ command-line wrapper for Git that adds features for GitHub repositories.
 Requirements
 ------------
 
-* Ansible >= 2.6
+* Ansible >= 2.7
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Ansible role for installing the Hub command line tool for GitHub.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.6
+  min_ansible_version: 2.7
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.7.